### PR TITLE
Correct sample server.json file to reflect README

### DIFF
--- a/irods-vfs-impl/config/server.json
+++ b/irods-vfs-impl/config/server.json
@@ -6,7 +6,7 @@
         "file_information_refresh_time_in_milliseconds": 1000
     },
 
-    "irods_server": {
+    "irods_client": {
         "zone": "tempZone",
         "host": "<hostname>",
         "port": 1247,


### PR DESCRIPTION
`irods_client` is the correct dict name, not `irods_server`.