### PR TITLE
Support sssd in the docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM ubuntu:16.04
+ARG sssd=false
 
 RUN apt-get update && \
     apt-get install -y apt-transport-https && \
-    apt-get install -y maven git openjdk-8-jdk
+    apt-get install -y maven git openjdk-8-jdk && \
+    apt-get install -y libnss-sss
 
 ARG _github_account="irods"
 ARG _sha="master"

--- a/README.md
+++ b/README.md
@@ -151,6 +151,25 @@ On startup, the NFSRODS server logs the build information (time, version, and gi
 $ docker run --rm nfsrods sha
 ```
 
+#### sssd integration
+
+In addition to a flat `/etc/passwd` file, the default nfsrods
+container also supports `libnss-sss`. It can be used by configuring
+sssd on the container host and binding the sssd socket into the
+container.
+
+```bash
+$ docker run -d --name nfsrods \
+             -p <public_port>:2049 \
+             -v </full/path/to/nfsrods_config>:/nfsrods_config:ro \
+             -v </full/path/to/etc/passwd/formatted/file>:/etc/passwd:ro \
+             -v /var/lib/sss:/var/lib/sss \
+             nfsrods
+```
+
+Using sssd, nfsrods can use any sssd domain for ID mapping, including
+AD or LDAP.
+
 ### Mounting
 ```bash
 $ sudo mkdir <mount_point>


### PR DESCRIPTION
The basic instructions for configuring id mapping in the
docker container is based around binding static passwd
and shadow files into the container. Supporting sssd allows
the host's sssd configuration to provide the id map.

Use `--build-arg sssd=true` during `docker build` to enable.

Use `--volume /var/lib/sss:/var/lib/sss` during `docker run`
to export the host's sssd to the container.