### PR TITLE
Support sssd in the docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM ubuntu:16.04
+ARG sssd=false
 
 RUN apt-get update && \
     apt-get install -y apt-transport-https && \
-    apt-get install -y maven git openjdk-8-jdk
+    apt-get install -y maven git openjdk-8-jdk && \
+    apt-get install -y libnss-sss
 
 ARG _github_account="irods"
 ARG _sha="master"

--- a/README.md
+++ b/README.md
@@ -158,6 +158,24 @@ If you want to connect NFSRODS to an iRODS Zone that is using SSL, a certificate
 
 The container will load any cert it finds at `/nfsrods_ssl.crt` within the container into the OpenJDK keystore.
 
+#### sssd integration
+
+As an alternative to an `/etc/passwd` file, the default NFSRODS container also
+supports `libnss-sss`. It can be used by configuring sssd on the container
+host and binding the sssd socket into the container.
+
+```bash
+$ docker run -d --name nfsrods \
+             -p <public_port>:2049 \
+             -v </full/path/to/nfsrods_config>:/nfsrods_config:ro \
+             -v /var/lib/sss:/var/lib/sss \
+             nfsrods
+```
+
+Using sssd, NFSRODS can use any sssd domain for ID mapping, including AD or
+LDAP. If sssd and `/etc/passwd` are used together, passwd will be consulted
+first.
+
 ### Mounting
 ```bash
 $ sudo mkdir <mount_point>


### PR DESCRIPTION
The basic instructions for configuring id mapping in the
docker container is based around binding static passwd
and shadow files into the container. Supporting sssd allows
the host's sssd configuration to provide the id map.

Use `--volume /var/lib/sss:/var/lib/sss` during `docker run`
to export the host's sssd to the container.