### PR TITLE
[#162] Updated README

### DIFF
--- a/irods-vfs-impl/pom.xml
+++ b/irods-vfs-impl/pom.xml
@@ -9,12 +9,12 @@
 	<parent>
 		<groupId>org.irods.jargon</groupId>
 		<artifactId>nfs4j-irodsvfs-pom</artifactId>
-		<version>2.0.4</version>
+		<version>2.1.0</version>
 	</parent>
 
 	<packaging>jar</packaging>
 	<name>nfsrods</name>
-	<version>2.0.4</version>
+	<version>2.1.0</version>
 	<description>iRODS VFS implementation for NFS4J</description>
 
 	<properties>

--- a/irods-vfs-impl/src/main/java/org/irods/nfsrods/vfs/IRODSVirtualFileSystem.java
+++ b/irods-vfs-impl/src/main/java/org/irods/nfsrods/vfs/IRODSVirtualFileSystem.java
@@ -108,7 +108,7 @@ public class IRODSVirtualFileSystem implements VirtualFileSystem, AclCheckable
     private final IRODSIdMapper idMapper_;
     private final InodeToPathMapper inodeToPathMapper_;
     private final IRODSAccount adminAcct_;
-    private final ReadWriteAclWhitelist readWriteAclWhitelist_;
+    private final ReadWriteAclAllowlist readWriteAclAllowlist_;
     private final boolean allowOverwriteOfExistingFiles_;
     private final boolean usingOracleDB_;
 
@@ -167,7 +167,7 @@ public class IRODSVirtualFileSystem implements VirtualFileSystem, AclCheckable
                                            rodsSvrConfig.getDefaultResource());
         // @formatter:on
 
-        readWriteAclWhitelist_ = new ReadWriteAclWhitelist(factory_, adminAcct_);
+        readWriteAclAllowlist_ = new ReadWriteAclAllowlist(factory_, adminAcct_);
         
         NFSServerConfig nfsSvrConfig = _config.getNfsServerConfig();
         allowOverwriteOfExistingFiles_ = nfsSvrConfig.allowOverwriteOfExistingFiles();
@@ -622,9 +622,9 @@ public class IRODSVirtualFileSystem implements VirtualFileSystem, AclCheckable
     
     private boolean isAllowedToReadWriteAclForPath(String _userName, String _path) throws JargonException
     {
-        if (readWriteAclWhitelist_.contains(_userName))
+        if (readWriteAclAllowlist_.contains(_userName))
         {
-            String prefix = readWriteAclWhitelist_.getPathPrefix(_userName);
+            String prefix = readWriteAclAllowlist_.getPathPrefix(_userName);
 
             log_.debug("isAllowedToReadWriteAclForPath - User path prefix = {}", prefix);
 
@@ -646,9 +646,9 @@ public class IRODSVirtualFileSystem implements VirtualFileSystem, AclCheckable
         {
             String groupName = ug.getUserGroupName();
 
-            if (readWriteAclWhitelist_.contains(groupName))
+            if (readWriteAclAllowlist_.contains(groupName))
             {
-                String prefix = readWriteAclWhitelist_.getPathPrefix(groupName);
+                String prefix = readWriteAclAllowlist_.getPathPrefix(groupName);
 
                 log_.debug("isAllowedToReadWriteAclForPath - Group path prefix = {}", prefix);
 
@@ -764,7 +764,7 @@ public class IRODSVirtualFileSystem implements VirtualFileSystem, AclCheckable
                     return Access.ALLOW;
                 }
                 
-                // Checks the ACL whitelist to see if the user should be allowed to read/write attributes and ACLs.
+                // Checks the ACL allowlist to see if the user should be allowed to read/write attributes and ACLs.
                 if (isAllowedToReadWriteAclForPath(userName, path))
                 {
                     log_.debug("checkAcl - User [{}] has special privileges to read/write ACLs, access allowed.", userName);

--- a/irods-vfs-impl/src/main/java/org/irods/nfsrods/vfs/ReadWriteAclAllowlist.java
+++ b/irods-vfs-impl/src/main/java/org/irods/nfsrods/vfs/ReadWriteAclAllowlist.java
@@ -24,9 +24,9 @@ import org.irods.jargon.core.query.RodsGenQueryEnum;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ReadWriteAclWhitelist
+public class ReadWriteAclAllowlist
 {
-    private static final Logger log_ = LoggerFactory.getLogger(ReadWriteAclWhitelist.class);
+    private static final Logger log_ = LoggerFactory.getLogger(ReadWriteAclAllowlist.class);
     
     private static final String GRANT_NFS4_SETFACL_PRIVILEGE = "irods::nfsrods::grant_nfs4_setfacl";
 
@@ -36,7 +36,7 @@ public class ReadWriteAclWhitelist
     private ReadWriteLock lock_;
     private ScheduledExecutorService scheduler_;
     
-    public ReadWriteAclWhitelist(IRODSAccessObjectFactory _factory,
+    public ReadWriteAclAllowlist(IRODSAccessObjectFactory _factory,
                                  IRODSAccount _adminAcct)
     {
         factory_ = _factory;
@@ -45,7 +45,7 @@ public class ReadWriteAclWhitelist
         lock_ = new ReentrantReadWriteLock();
         scheduler_ = Executors.newSingleThreadScheduledExecutor();
 
-        // Periodically update the nfs4_setfacl whitelist.
+        // Periodically update the nfs4_setfacl allowlist.
         scheduler_.scheduleAtFixedRate(() -> {
             Lock lk = lock_.writeLock();
             

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.irods.jargon</groupId>
 	<artifactId>nfs4j-irodsvfs-pom</artifactId>
-	<version>2.0.4</version>
+	<version>2.1.0</version>
 	<parent>
 		<groupId>org.irods</groupId>
 		<artifactId>jargon-pom</artifactId>


### PR DESCRIPTION
for next release.

release version number suggestions:
- 2.1.0
  - at the moment, i think this is the most appropriate version
  - this signals, "Hey, we changed some things, but you're safe to upgrade. Consider looking over the README."
- 3.0.0
  - this feels like overkill
  - for the most part, only the internals of the app have changed

we need to consider what things constitute a breaking change in regards to NFSRODS
  - shutdown handling is slightly different (use ctrl-c)
  - building is a two-step process now (docker image no longer builds jar)
  - docker run does not require `-i`