### PR TITLE
[#179] Fix build failure caused by OpenJDK 17.0.7 dependency issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ENV PATH "$JAVA_HOME/bin:$PATH"
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update && apt-get upgrade -y && \
     apt-get install -y apt-transport-https && \
+    apt-get install -y ca-certificates-java && \
     apt-get install -y openjdk-17-jdk libnss-sss
 
 # Provide default log4j configuration.


### PR DESCRIPTION
The release of OpenJDK 17.0.7 on Ubuntu 18.04 appears to have introduced dependency issues with ca-certificates-java.  If ca-certificates-java isn't explicitly installed before installing openjdk-17-jdk, the build will fail.