### PR TITLE
[#205] Add iRODS server version check to resize operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ A user can set permissions via `nfs4_setfacl` on a collection or data object if 
 ## Notes
 - `chmod` is currently implemented as a `NOP` and will return `0`.
 - NFSRODS currently reports disk free (`df -a`) as `0` to avoid being misleading to other programs.
+- Resizing data objects requires iRODS 4.3.2 or later.
 
 ## Limitations
 ### Limitation 1: Write operations do not trigger replication on a replication resource

--- a/irods-vfs-impl/src/main/java/org/irods/nfsrods/vfs/IRODSVirtualFileSystem.java
+++ b/irods-vfs-impl/src/main/java/org/irods/nfsrods/vfs/IRODSVirtualFileSystem.java
@@ -1405,6 +1405,11 @@ public class IRODSVirtualFileSystem implements VirtualFileSystem, AclCheckable
 
             try
             {
+                if (!factory_.getIRODSServerProperties(acct).isAtLeastIrods432())
+                {
+                    throw new IOException("iRODS server does not support rc_replica_truncate API. Requires iRODS 4.3.2 or later.");
+                }
+
                 final var path = getPath(toInodeNumber(_inode));
                 log_.debug("setattr - Setting data size of [{}] to [{}] bytes.", path.toString(), _stat.getSize());
                 factory_.getDataObjectAO(acct).truncateReplica(path.toString(), _stat.getSize());


### PR DESCRIPTION
This PR originally logged a warning on server startup about the replica truncate API not being supported. That approach was dropped due to NFSRODS becoming unresponsive after attempting to invoke the replica truncate API on a 4.3.1 server.

I've updated the code to check if replica truncate is supported before attempting to invoke it. If the API is not supported, an exception will be thrown. Throwing an exception is important because it lets the user know things didn't work. This approach also allows NFSRODS to remain compatible with earlier versions of iRODS.

The first commit contains the original work. Those changes will be reverted following the squash.