### PR TITLE
Make NFSRODS compatible with iRODS 5 (main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project **only** adheres to the following _(as defined at [Semantic Versioning](https://semver.org/spec/v2.0.0.html))_:
+
+> Given a version number MAJOR.MINOR.PATCH, increment the:
+> 
+> - MAJOR version when you make incompatible API changes
+> - MINOR version when you add functionality in a backward compatible manner
+> - PATCH version when you make backward compatible bug fixes
+
+## [2.3.1] - 2025-07-22
+
+This release updates dependencies so that NFSRODS is compatible with iRODS 5.
+
+### Changed
+
+- Bump Jargon version to 4.3.7.0 for iRODS 5 compatibility (#215).

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ ARG sssd=false
 
 # The following environment variables are required to avoid errors
 # during the installation of openjdk-17-jdk.
-ENV JAVA_HOME "/usr/lib/jvm/java-17-openjdk-amd64"
-ENV PATH "$JAVA_HOME/bin:$PATH"
+ENV JAVA_HOME="/usr/lib/jvm/java-17-openjdk-amd64"
+ENV PATH="$JAVA_HOME/bin:$PATH"
 
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update && apt-get upgrade -y && \

--- a/irods-vfs-impl/pom.xml
+++ b/irods-vfs-impl/pom.xml
@@ -9,12 +9,12 @@
 	<parent>
 		<groupId>org.irods.jargon</groupId>
 		<artifactId>nfs4j-irodsvfs-pom</artifactId>
-		<version>2.3.0</version>
+		<version>2.3.1</version>
 	</parent>
 
 	<packaging>jar</packaging>
 	<name>nfsrods</name>
-	<version>2.3.0</version>
+	<version>2.3.1</version>
 	<description>iRODS VFS implementation for NFS4J</description>
 
 	<properties>

--- a/irods-vfs-impl/pom.xml
+++ b/irods-vfs-impl/pom.xml
@@ -47,21 +47,6 @@
 			<artifactId>jargon-core</artifactId>
 			<exclusions>
 				<exclusion>
-					<groupId>log4j</groupId>
-					<artifactId>log4j</artifactId>
-				</exclusion>
-
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-api</artifactId>
-				</exclusion>
-				
-				<exclusion>
-					<groupId>org.slf4</groupId>
-					<artifactId>slf4j-log4j12</artifactId>
-				</exclusion>
-				
-				<exclusion>
 					<groupId>com.fasterxml.jackson.core</groupId>
 					<artifactId>jackson-core</artifactId>
 				</exclusion>
@@ -82,21 +67,6 @@
 			<groupId>org.irods.jargon</groupId>
 			<artifactId>jargon-pool</artifactId>
 			<exclusions>
-				<exclusion>
-					<groupId>log4j</groupId>
-					<artifactId>log4j</artifactId>
-				</exclusion>
-				
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-api</artifactId>
-				</exclusion>
-				
-				<exclusion>
-					<groupId>org.slf4</groupId>
-					<artifactId>slf4j-log4j12</artifactId>
-				</exclusion>
-				
 				<exclusion>
 					<groupId>com.fasterxml.jackson.core</groupId>
 					<artifactId>jackson-core</artifactId>
@@ -121,33 +91,15 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>2.0.0-alpha5</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.17.1</version>
+			<version>${log4j.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.17.1</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-1.2-api</artifactId>
-			<version>2.17.1</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>2.17.1</version>
+			<version>${log4j.version}</version>
 		</dependency>
 
 		<dependency>
@@ -197,6 +149,13 @@
 			<groupId>org.ehcache</groupId>
 			<artifactId>ehcache</artifactId>
 			<version>3.7.0</version>
+		</dependency>
+
+		<!-- This dependency is used to keep ehcache's use of slf4j quiet on startup. -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-nop</artifactId>
+			<version>1.7.25</version>
 		</dependency>
 
 		<dependency>

--- a/irods-vfs-impl/src/main/java/org/irods/nfsrods/vfs/IRODSIdMapper.java
+++ b/irods-vfs-impl/src/main/java/org/irods/nfsrods/vfs/IRODSIdMapper.java
@@ -14,14 +14,14 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.cliffc.high_scale_lib.NonBlockingHashMap;
 import org.dcache.nfs.v4.NfsIdMapping;
 import org.irods.jargon.core.pub.IRODSAccessObjectFactory;
 import org.irods.nfsrods.config.IRODSProxyAdminAccountConfig;
 import org.irods.nfsrods.config.NFSServerConfig;
 import org.irods.nfsrods.config.ServerConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.sun.jna.Library;
 import com.sun.jna.Native;
@@ -32,7 +32,7 @@ import com.sun.jna.ptr.IntByReference;
 
 public class IRODSIdMapper implements NfsIdMapping
 {
-    private static final Logger log_ = LoggerFactory.getLogger(IRODSIdMapper.class);
+    private static final Logger log_ = LogManager.getLogger(IRODSIdMapper.class);
 
     private static final LibC libc_ = (LibC) Native.load("c", LibC.class);
 

--- a/irods-vfs-impl/src/main/java/org/irods/nfsrods/vfs/IRODSUser.java
+++ b/irods-vfs-impl/src/main/java/org/irods/nfsrods/vfs/IRODSUser.java
@@ -2,18 +2,18 @@ package org.irods.nfsrods.vfs;
 
 import java.nio.file.Paths;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.irods.jargon.core.connection.IRODSAccount;
 import org.irods.jargon.core.pub.IRODSAccessObjectFactory;
 import org.irods.nfsrods.config.IRODSClientConfig;
 import org.irods.nfsrods.config.IRODSProxyAdminAccountConfig;
 import org.irods.nfsrods.config.NFSServerConfig;
 import org.irods.nfsrods.config.ServerConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class IRODSUser
 {
-    private static final Logger log_ = LoggerFactory.getLogger(IRODSIdMapper.class);
+    private static final Logger log_ = LogManager.getLogger(IRODSIdMapper.class);
 
     private IRODSAccount proxiedAcct_;
     private int userID_;

--- a/irods-vfs-impl/src/main/java/org/irods/nfsrods/vfs/IRODSVirtualFileSystem.java
+++ b/irods-vfs-impl/src/main/java/org/irods/nfsrods/vfs/IRODSVirtualFileSystem.java
@@ -45,6 +45,9 @@ import javax.cache.expiry.CreatedExpiryPolicy;
 import javax.cache.expiry.Duration;
 import javax.security.auth.Subject;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import org.dcache.auth.Subjects;
 import org.dcache.nfs.ChimeraNFSException;
 import org.dcache.nfs.status.ExistException;
@@ -103,14 +106,11 @@ import org.irods.nfsrods.config.IRODSProxyAdminAccountConfig;
 import org.irods.nfsrods.config.NFSServerConfig;
 import org.irods.nfsrods.config.ServerConfig;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.primitives.Longs;
 
 public class IRODSVirtualFileSystem implements VirtualFileSystem, AclCheckable
 {
-    private static final Logger log_ = LoggerFactory.getLogger(IRODSVirtualFileSystem.class);
+    private static final Logger log_ = LogManager.getLogger(IRODSVirtualFileSystem.class);
 
     private static final long FIXED_TIMESTAMP = System.currentTimeMillis();
     private static final FsStat FILE_SYSTEM_STAT_INFO = new FsStat(0, 0, 0, 0);

--- a/irods-vfs-impl/src/main/java/org/irods/nfsrods/vfs/InodeToPathMapper.java
+++ b/irods-vfs-impl/src/main/java/org/irods/nfsrods/vfs/InodeToPathMapper.java
@@ -10,6 +10,8 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.irods.jargon.core.connection.IRODSAccount;
 import org.irods.jargon.core.exception.DataNotFoundException;
 import org.irods.jargon.core.exception.JargonException;
@@ -21,12 +23,10 @@ import org.irods.nfsrods.config.IRODSClientConfig;
 import org.irods.nfsrods.config.IRODSProxyAdminAccountConfig;
 import org.irods.nfsrods.config.NFSServerConfig;
 import org.irods.nfsrods.config.ServerConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class InodeToPathMapper
 {
-    private static final Logger log_ = LoggerFactory.getLogger(IRODSIdMapper.class);
+    private static final Logger log_ = LogManager.getLogger(IRODSIdMapper.class);
 
     private Map<Long, Path> inodeToPath_;
     private Map<Path, Long> pathToInode_;

--- a/irods-vfs-impl/src/main/java/org/irods/nfsrods/vfs/ReadWriteAclAllowlist.java
+++ b/irods-vfs-impl/src/main/java/org/irods/nfsrods/vfs/ReadWriteAclAllowlist.java
@@ -10,6 +10,8 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.irods.jargon.core.connection.IRODSAccount;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.pub.IRODSAccessObjectFactory;
@@ -21,12 +23,10 @@ import org.irods.jargon.core.query.IRODSQueryResultSet;
 import org.irods.jargon.core.query.JargonQueryException;
 import org.irods.jargon.core.query.QueryConditionOperators;
 import org.irods.jargon.core.query.RodsGenQueryEnum;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ReadWriteAclAllowlist
 {
-    private static final Logger log_ = LoggerFactory.getLogger(ReadWriteAclAllowlist.class);
+    private static final Logger log_ = LogManager.getLogger(ReadWriteAclAllowlist.class);
     
     private static final String GRANT_NFS4_SETFACL_PRIVILEGE = "irods::nfsrods::grant_nfs4_setfacl";
 

--- a/irods-vfs-impl/src/main/java/org/irods/nfsrods/vfs/ServerMain.java
+++ b/irods-vfs-impl/src/main/java/org/irods/nfsrods/vfs/ServerMain.java
@@ -10,6 +10,7 @@ import javax.cache.Caching;
 import javax.cache.spi.CachingProvider;
 
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.dcache.nfs.ExportFile;
 import org.dcache.nfs.v4.MDSOperationExecutor;
 import org.dcache.nfs.v4.NFSServerV41;
@@ -33,8 +34,6 @@ import org.irods.jargon.pool.conncache.JargonPooledObjectFactory;
 import org.irods.nfsrods.config.NFSServerConfig;
 import org.irods.nfsrods.config.ServerConfig;
 import org.irods.nfsrods.utils.JSONUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ServerMain
 {
@@ -45,7 +44,7 @@ public class ServerMain
     private static final String GIT_PROPERTIES      = "/git.properties";
     // @formatter:on
 
-    private static final Logger log_ = LoggerFactory.getLogger(ServerMain.class);
+    private static final Logger log_ = LogManager.getLogger(ServerMain.class);
     private static final AtomicBoolean shutdownFlag = new AtomicBoolean();
 
     public static void main(String[] args) throws JargonException, IOException

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.irods</groupId>
 		<artifactId>jargon-pom</artifactId>
-		<version>4.3.4.0-SNAPSHOT</version>
+		<version>4.3.7.0-RELEASE</version>
 	</parent>
 
 	<packaging>pom</packaging>
@@ -18,7 +18,7 @@
 	<description>iRODS NFS4J Virtual File System</description>
 
 	<properties>
-		<jargon.version>4.3.4.0-SNAPSHOT</jargon.version>
+		<jargon.version>4.3.7.0-RELEASE</jargon.version>
 	</properties>
 
 	<organization>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.irods.jargon</groupId>
 	<artifactId>nfs4j-irodsvfs-pom</artifactId>
-	<version>2.3.0</version>
+	<version>2.3.1</version>
 	<parent>
 		<groupId>org.irods</groupId>
 		<artifactId>jargon-pom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<repository>
 			<id>dice.repository</id>
 			<name>dice.repository</name>
-			<url>https://raw.githubusercontent.com/irods/irods_maven/main/releases</url>
+			<url>https://raw.githubusercontent.com/DICE-UNC/DICE-Maven/master/releases</url>
 			<releases>
 				<enabled>true</enabled>
 			</releases>
@@ -43,7 +43,7 @@
 		<repository>
 			<id>dice.repository snaps</id>
 			<name>dice.repository.snapshots</name>
-			<url>https://raw.githubusercontent.com/irods/irods_maven/main/snapshots</url>
+			<url>https://raw.githubusercontent.com/DICE-UNC/DICE-Maven/master/snapshots</url>
 			<releases>
 				<enabled>true</enabled>
 			</releases>


### PR DESCRIPTION
Confirmed docker image builds without any issues.

Test suite passes when run against iRODS 4.3.4 and 5.0.1.
A containerized version of NFSRODS was used for both test runs.

Startup is slightly noisy due to changes in dependencies.
```
2025-07-18 22:05:11.202 DEBUG Thread-1 [ServerMain] - configureClientServerNegotiationPolicy - Policy = CS_NEG_REFUSE
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
2025-07-18 22:05:11.373 DEBUG Thread-1 [IRODSIdMapper] - IRODSUser - iRODS mount point = /tempZone
2025-07-18 22:05:11.373 DEBUG Thread-1 [IRODSIdMapper] - IRODSUser - Creating proxy for username [rods] ...
2025-07-18 22:05:11.942 DEBUG Thread-1 [IRODSIdMapper] - InodeToPathMapper - iRODS mount point = /tempZone
2025-07-18 22:05:12.196 DEBUG Thread-1 [IRODSIdMapper] - establishRoot - Mapping root to [irods://rods@[REDACTED]:1247/tempZone] ...
2025-07-18 22:05:12.197 DEBUG Thread-1 [IRODSIdMapper] - map - mapping inode number to path [10004 => /tempZone] ...
2025-07-18 22:05:12.197 DEBUG Thread-1 [IRODSIdMapper] - map - previously mapped path [null]
2025-07-18 22:05:12.198 DEBUG Thread-1 [IRODSIdMapper] - establishRoot - Mapping successful.
2025-07-18 22:05:20.483 INFO  Thread-1 [ServerMain] - main - Press ctrl-c to shutdown.
SLF4J: Failed to load class "org.slf4j.impl.StaticMDCBinder".
SLF4J: Defaulting to no-operation MDCAdapter implementation.
SLF4J: See http://www.slf4j.org/codes.html#no_static_mdc_binder for further details.
2025-07-18 22:05:24.905 DEBUG Thread-39 [IRODSVirtualFileSystem] - vfs::checkAcl
2025-07-18 22:05:24.905 DEBUG Thread-39 [IRODSIdMapper] - resolveUser - _userID = 0
```

It's not clear to me whether we can fix that, but functionally, the application is in good shape. We may need to bump the version of the ehcache dependency. Hmm...

This PR does not introduce any changes in behavior, hence the version being set to 2.3.1.